### PR TITLE
Fix/network attempts loop + Supervision restart script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "ore-cli"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "bs58 0.5.1",

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -16,6 +16,7 @@ use solana_sdk::{
     transaction::{Transaction, TransactionError},
 };
 use solana_transaction_status::UiTransactionEncoding;
+use tokio::time::sleep;
 
 use crate::Miner;
 
@@ -31,10 +32,24 @@ impl Miner {
             RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
 
         // Build tx
-        let (mut hash, mut slot) = client
-            .get_latest_blockhash_with_commitment(CommitmentConfig::confirmed())
-            .await
-            .unwrap();
+        let mut attempts = 0;
+        const MAX_ATTEMPTS: u8 = 3; // Maximum number of attempts before giving up
+        let retry_delay = Duration::from_secs(5); // Delay between retries
+        
+        let (mut hash, mut slot) = loop {
+            match client.get_latest_blockhash_with_commitment(CommitmentConfig::confirmed()).await {
+                Ok(result) => break result,
+                Err(e) => {
+                    attempts += 1;
+                    if attempts >= MAX_ATTEMPTS {
+                        panic!("Failed to get latest blockhash after {} attempts: {:?}", MAX_ATTEMPTS, e);
+                    }
+                    eprintln!("Attempt {} failed, retrying in {:?}: {:?}", attempts, retry_delay, e);
+                    sleep(retry_delay).await;
+                }
+            }
+        };        
+
         let mut send_cfg = RpcSendTransactionConfig {
             skip_preflight: true,
             preflight_commitment: Some(CommitmentLevel::Confirmed),

--- a/supervision.sh
+++ b/supervision.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Check if at least one argument is given
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <RPC_URL>"
+    exit 1
+fi
+
+# Assign the first argument to RPC_URL
+RPC_URL=$1
+
+# Command and its arguments, with dynamic RPC URL
+COMMAND="./target/release/ore --rpc ${RPC_URL} --keypair ~/.config/solana/id2.json --priority-fee 5000000 mine --threads 8"
+
+# Loop indefinitely
+while true; do
+  echo "Starting the process..."
+  
+  # Execute the command
+  eval $COMMAND
+  
+  # If the command was successful, exit the loop
+  # Remove this if you always want to restart regardless of exit status
+  [ $? -eq 0 ] && break
+  
+  echo "Process exited with an error. Restarting in 5 seconds..."
+  sleep 5
+done


### PR DESCRIPTION
Attempt loops to network related requests, to mitigate RPC limit rates and failed simulations

on mine.rs
utils.rs
register.rs
send_and_confirm.rs

and a small bash script to restart the process if panic occurs.

Not a solution, but a work around that I made, in the meanwhile I study the code.