### PR TITLE
Cargo lock update bump ore-cli to 0.4.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "ore-cli"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "bincode",
  "bs58 0.5.1",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.76.0"
 components = [ "rustfmt", "rust-analyzer" ]
 profile = "minimal"
 


### PR DESCRIPTION
It appears that the Cargo.lock is lagging behind the Cargo.toml version. When cloning from source, rust automatically generates the correct Cargo.lock file which creates an automatic change. 

Would be good to generate new lock file when pushing or create an action that does it automaticallly.