### PR TITLE
preserve the rpc client connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "ore-cli"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "bincode",
  "bs58 0.5.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "ore-cli"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "bincode",
  "bs58 0.5.1",
@@ -2447,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "ore-program"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1438154357d3952bd1d8f683d7ded7977a317b86495031313a6a8799afe2ec8"
+checksum = "fcf2aafa6b257df0f423042e69eb7dd5dbc90a03f2469b986b14401dc6570246"
 dependencies = [
  "bs58 0.5.1",
  "bytemuck",

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -1,8 +1,7 @@
 use std::str::FromStr;
 
-use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_program::pubkey::Pubkey;
-use solana_sdk::{commitment_config::CommitmentConfig, signature::Signer};
+use solana_sdk::signature::Signer;
 
 use crate::Miner;
 
@@ -19,8 +18,7 @@ impl Miner {
         } else {
             signer.pubkey()
         };
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
+        let client = self.rpc_client.clone();
         let token_account_address = spl_associated_token_account::get_associated_token_address(
             &address,
             &ore::MINT_ADDRESS,

--- a/src/busses.rs
+++ b/src/busses.rs
@@ -1,13 +1,11 @@
 use ore::{state::Bus, utils::AccountDeserialize, BUS_ADDRESSES};
-use solana_client::{client_error::Result, nonblocking::rpc_client::RpcClient};
-use solana_sdk::commitment_config::CommitmentConfig;
+use solana_client::client_error::Result;
 
 use crate::Miner;
 
 impl Miner {
     pub async fn busses(&self) {
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
+        let client = self.rpc_client.clone();
         for address in BUS_ADDRESSES.iter() {
             let data = client.get_account_data(address).await.unwrap();
             match Bus::try_from_bytes(&data) {
@@ -20,8 +18,7 @@ impl Miner {
     }
 
     pub async fn get_bus(&self, id: usize) -> Result<Bus> {
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
+        let client = self.rpc_client.clone();
         let data = client.get_account_data(&BUS_ADDRESSES[id]).await?;
         Ok(*Bus::try_from_bytes(&data).unwrap())
     }

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -1,20 +1,19 @@
 use std::str::FromStr;
 
 use ore::{self, state::Proof, utils::AccountDeserialize};
-use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_program::pubkey::Pubkey;
 use solana_sdk::{
-    commitment_config::CommitmentConfig, compute_budget::ComputeBudgetInstruction,
+    compute_budget::ComputeBudgetInstruction,
     signature::Signer,
 };
 
 use crate::{cu_limits::CU_LIMIT_CLAIM, utils::proof_pubkey, Miner};
 
 impl Miner {
-    pub async fn claim(&self, cluster: String, beneficiary: Option<String>, amount: Option<f64>) {
+    pub async fn claim(&self, beneficiary: Option<String>, amount: Option<f64>) {
         let signer = self.signer();
         let pubkey = signer.pubkey();
-        let client = RpcClient::new_with_commitment(cluster, CommitmentConfig::confirmed());
+        let client = self.rpc_client.clone();
         let beneficiary = match beneficiary {
             Some(beneficiary) => {
                 Pubkey::from_str(&beneficiary).expect("Failed to parse beneficiary address")
@@ -57,8 +56,7 @@ impl Miner {
     async fn initialize_ata(&self) -> Pubkey {
         // Initialize client.
         let signer = self.signer();
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
+        let client = self.rpc_client.clone();
 
         // Build instructions.
         let token_account_pubkey = spl_associated_token_account::get_associated_token_address(

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -1,6 +1,6 @@
 use ore::TREASURY_ADDRESS;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{commitment_config::CommitmentConfig, signature::Signer};
+
+use solana_sdk::signature::Signer;
 
 use crate::Miner;
 
@@ -8,15 +8,14 @@ impl Miner {
     pub async fn initialize(&self) {
         // Return early if program is initialized
         let signer = self.signer();
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
+        let client = self.rpc_client.clone();
         if client.get_account(&TREASURY_ADDRESS).await.is_ok() {
             return;
         }
 
         // Sign and send transaction.
         let ix = ore::instruction::initialize(signer.pubkey());
-        self.send_and_confirm(&[ix], false)
+        self.send_and_confirm(&[ix], false, false)
             .await
             .expect("Transaction failed");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,8 +192,7 @@ async fn main() {
     // Initialize miner.
     let cluster = args.rpc.unwrap_or(cli_config.json_rpc_url);
     let default_keypair = args.keypair.unwrap_or(cli_config.keypair_path);
-
-    let rpc_client = RpcClient::new_with_commitment(cluster, CommitmentConfig::confirmed());
+    let rpc_client = RpcClient::new_with_commitment(cluster, CommitmentConfig::finalized());
 
     let miner = Arc::new(Miner::new(
         Arc::new(rpc_client),

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,12 +18,16 @@ mod utils;
 use std::sync::Arc;
 
 use clap::{command, Parser, Subcommand};
-use solana_sdk::signature::{read_keypair_file, Keypair};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::{
+    commitment_config::CommitmentConfig,
+    signature::{read_keypair_file, Keypair},
+};
 
 struct Miner {
     pub keypair_filepath: Option<String>,
     pub priority_fee: u64,
-    pub cluster: String,
+    pub rpc_client: Arc<RpcClient>,
 }
 
 #[derive(Parser, Debug)]
@@ -189,8 +193,10 @@ async fn main() {
     let cluster = args.rpc.unwrap_or(cli_config.json_rpc_url);
     let default_keypair = args.keypair.unwrap_or(cli_config.keypair_path);
 
+    let rpc_client = RpcClient::new_with_commitment(cluster, CommitmentConfig::confirmed());
+
     let miner = Arc::new(Miner::new(
-        cluster.clone(),
+        Arc::new(rpc_client),
         args.priority_fee,
         Some(default_keypair),
     ));
@@ -213,7 +219,7 @@ async fn main() {
             miner.mine(args.threads).await;
         }
         Commands::Claim(args) => {
-            miner.claim(cluster, args.beneficiary, args.amount).await;
+            miner.claim(args.beneficiary, args.amount).await;
         }
         #[cfg(feature = "admin")]
         Commands::Initialize(_) => {
@@ -231,11 +237,11 @@ async fn main() {
 }
 
 impl Miner {
-    pub fn new(cluster: String, priority_fee: u64, keypair_filepath: Option<String>) -> Self {
+    pub fn new(rpc_client: Arc<RpcClient>, priority_fee: u64, keypair_filepath: Option<String>) -> Self {
         Self {
+            rpc_client,
             keypair_filepath,
             priority_fee,
-            cluster,
         }
     }
 

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -53,7 +53,7 @@ impl Miner {
             println!("\n\nSubmitting hash for validation...");
             'submit: loop {
                 // Double check we're submitting for the right challenge
-                let proof_ = get_proof(self.cluster.clone(), signer.pubkey()).await;
+                let proof_ = get_proof(&self.rpc_client, signer.pubkey()).await;
                 if proof_.hash.ne(&proof.hash) {
                     println!("Hash already validated! An earlier transaction must have landed.");
                     break 'submit;

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,5 +1,4 @@
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{commitment_config::CommitmentConfig, signature::Signer};
+use solana_sdk::signature::Signer;
 
 use crate::{utils::proof_pubkey, Miner};
 
@@ -8,8 +7,7 @@ impl Miner {
         // Return early if miner is already registered
         let signer = self.signer();
         let proof_address = proof_pubkey(signer.pubkey());
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
+        let client = self.rpc_client.clone();
         if client.get_account(&proof_address).await.is_ok() {
             return;
         }

--- a/src/rewards.rs
+++ b/src/rewards.rs
@@ -17,7 +17,7 @@ impl Miner {
         } else {
             self.signer().pubkey()
         };
-        let proof = get_proof(self.cluster.clone(), address).await;
+        let proof = get_proof(&self.rpc_client, address).await;
         let amount = (proof.claimable_rewards as f64) / 10f64.powf(ore::TOKEN_DECIMALS as f64);
         println!("{:} ORE", amount);
     }

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -5,7 +5,6 @@ use std::{
 
 use solana_client::{
     client_error::{ClientError, ClientErrorKind, Result as ClientResult},
-    nonblocking::rpc_client::RpcClient,
     rpc_config::{RpcSendTransactionConfig, RpcSimulateTransactionConfig},
 };
 use solana_program::instruction::Instruction;
@@ -33,8 +32,7 @@ impl Miner {
     ) -> ClientResult<Signature> {
         let mut stdout = stdout();
         let signer = self.signer();
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
+        let client = self.rpc_client.clone();
 
         // Return error if balance is zero
         let balance = client

--- a/src/treasury.rs
+++ b/src/treasury.rs
@@ -1,6 +1,3 @@
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::commitment_config::CommitmentConfig;
-
 use crate::{
     utils::{get_treasury, treasury_tokens_pubkey},
     Miner,
@@ -8,11 +5,10 @@ use crate::{
 
 impl Miner {
     pub async fn treasury(&self) {
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
+        let client = self.rpc_client.clone();
         if let Ok(Some(treasury_tokens)) = client.get_token_account(&treasury_tokens_pubkey()).await
         {
-            let treasury = get_treasury(self.cluster.clone()).await;
+            let treasury = get_treasury(&self.rpc_client).await;
             let balance = treasury_tokens.token_amount.ui_amount_string;
             println!("{:} ORE", balance);
             println!("Admin: {}", treasury.admin);

--- a/src/update_admin.rs
+++ b/src/update_admin.rs
@@ -10,7 +10,7 @@ impl Miner {
         let signer = self.signer();
         let new_admin = Pubkey::from_str(new_admin.as_str()).unwrap();
         let ix = ore::instruction::update_admin(signer.pubkey(), new_admin);
-        self.send_and_confirm(&[ix], false)
+        self.send_and_confirm(&[ix], false, false)
             .await
             .expect("Transaction failed");
     }

--- a/src/update_difficulty.rs
+++ b/src/update_difficulty.rs
@@ -17,7 +17,7 @@ impl Miner {
         let ix = ore::instruction::update_difficulty(signer.pubkey(), new_difficulty.into());
         // let bs58data = bs58::encode(ix.data).into_string();
         // println!("Data: {:?}", bs58data);
-        self.send_and_confirm(&[ix], false)
+        self.send_and_confirm(&[ix], false, false)
             .await
             .expect("Transaction failed");
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,11 +7,10 @@ use ore::{
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_program::{pubkey::Pubkey, sysvar};
-use solana_sdk::{clock::Clock, commitment_config::CommitmentConfig};
+use solana_sdk::clock::Clock;
 use spl_associated_token_account::get_associated_token_address;
 
-pub async fn get_treasury(cluster: String) -> Treasury {
-    let client = RpcClient::new_with_commitment(cluster, CommitmentConfig::confirmed());
+pub async fn get_treasury(client: &RpcClient) -> Treasury {
     let data = client
         .get_account_data(&TREASURY_ADDRESS)
         .await
@@ -19,8 +18,7 @@ pub async fn get_treasury(cluster: String) -> Treasury {
     *Treasury::try_from_bytes(&data).expect("Failed to parse treasury account")
 }
 
-pub async fn get_proof(cluster: String, authority: Pubkey) -> Proof {
-    let client = RpcClient::new_with_commitment(cluster, CommitmentConfig::confirmed());
+pub async fn get_proof(client: &RpcClient, authority: Pubkey) -> Proof {
     let proof_address = proof_pubkey(authority);
     let data = client
         .get_account_data(&proof_address)
@@ -29,8 +27,7 @@ pub async fn get_proof(cluster: String, authority: Pubkey) -> Proof {
     *Proof::try_from_bytes(&data).expect("Failed to parse miner account")
 }
 
-pub async fn get_clock_account(cluster: String) -> Clock {
-    let client = RpcClient::new_with_commitment(cluster, CommitmentConfig::confirmed());
+pub async fn get_clock_account(client: &RpcClient) -> Clock {
     let data = client
         .get_account_data(&sysvar::clock::ID)
         .await


### PR DESCRIPTION
One RpcClient to rule them all.

Pros:
- uses fewer local system resources
- uses fewer rpc server resources
- consistency
Why:
- mainly connection pooling