### PR TITLE
Fix `Err` Balance & Channel Version Build Error

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.75.0"
 components = [ "rustfmt", "rust-analyzer" ]
 profile = "minimal"
 

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -207,8 +207,7 @@ impl Miner {
     }
 
     pub async fn get_ore_display_balance(&self) -> String {
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
+        let client = RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
         let signer = self.signer();
         let token_account_address = spl_associated_token_account::get_associated_token_address(
             &signer.pubkey(),
@@ -222,7 +221,7 @@ impl Miner {
                     "0.00".to_string()
                 }
             }
-            Err(_) => "Err".to_string(),
+            Err(_) => "0".to_string(),
         }
     }
 }


### PR DESCRIPTION
- Fix Balance showing `Err ORE` to `0 ORE` 
- Fix rust channel version error. Requires 1.75.0 minimum